### PR TITLE
Call fence on all threads during 1 win per thread test

### DIFF
--- a/src/rmamt_bw.c
+++ b/src/rmamt_bw.c
@@ -212,7 +212,7 @@ int main(int argc,char *argv[])
             args[i].min_size = min_size;
             args[i].win = rmamt_win_per_thread ? win[i] : win[0];
             args[i].group = group;
-            args[i].all_sync = (RMAMT_ALL_FLUSH == rmamt_sync);
+            args[i].all_sync = (RMAMT_ALL_FLUSH == rmamt_sync) || (RMAMT_FENCE == rmamt_sync);
             args[i].target = !(rank & 1);
             args[i].comm = leader_comm;
 


### PR DESCRIPTION
@hjelmn 
I was running the multiple windows, multiple threads test and I noticed that the benchmark hangs during final phase (after the put/get measurements are completed.)

I noticed that when thread count >= 2, and multiple windows are used. The test is setup such that `args[tid].do_fence` is set to true only for thread 0.
This leads to a `MPI_Win_fence()` call count mismatch between initiator and target threads.
However, since the fence call is a collective operation and calls `MPI_Barrier()` under the hood this undoubtedly leads to a hang when threads should be joining.
The bellow "fix" avoids this by calling `MPI_Win_fence()` on all threads. Basically, setting all_sync check during thread creation.

What do you think? Am I misunderstanding the benchmark? 

Note, I did not check other synchronization calls.
The runtime command I used was:
`$mpirun -np 2 --map-by node --bind-to none -H jazz31:1,jazz32:1 --mca pml ob1 --mca osc rdma --mca btl uct --mca btl_uct_memory_domains ib/mlx5_2 --mca tl_uct_transports dc_mlx5 ./rmamt_bw -w -t 16 -x -o put -s fence`