### PR TITLE
fix(cmd_parse): command parsing on arm machines

### DIFF
--- a/src/rmamt_options.c
+++ b/src/rmamt_options.c
@@ -76,7 +76,9 @@ static void print_usage (const char *name, bool failure)
 
 int rmamt_parse_options (const char *name, int argc, char *argv[])
 {
-    char c, *tmp;
+    char *tmp;
+    int c;
+
     const struct option options[] = {
 	{"win-per-thread", no_argument, NULL, 'w'},
 	{"max-size", required_argument, NULL, 'm'},


### PR DESCRIPTION
# Problem

This benchmark will always exit through the `print_usage` in the default switch case on ARM machines.

https://github.com/hpc/rma-mt/blob/d09c4d06730b25c06ca91cf2070e857a6be9e87a/src/rmamt_options.c#L234-L236

As the `getlong_opt` returns an int and c is defined as `char`

https://github.com/hpc/rma-mt/blob/d09c4d06730b25c06ca91cf2070e857a6be9e87a/src/rmamt_options.c#L109

https://github.com/hpc/rma-mt/blob/d09c4d06730b25c06ca91cf2070e857a6be9e87a/src/rmamt_options.c#L79

On `x86` this is not an issue but on `arm` this can never exit as -1 will be converted into 255 and it end up in the default switch statement.

# This PR fixes

* fixing command parsing as some compiler do not auto correct the -1 to a char type

* also I needed to use ./configure LIBS="-lpthread" to make it compile


## More infos
[Compiler Explorer](https://godbolt.org/#z:OYLghAFBqd5QCxAYwPYBMCmBRdBLAF1QCcAaPECAMzwBtMA7AQwFtMQByARg9KtQYEAysib0QXACx8BBAKoBnTAAUAHpwAMvAFYTStJg1DIApACYAQuYukl9ZATwDKjdAGFUtAK4sGe1wAyeAyYAHI%2BAEaYxCBmXKQADqgKhE4MHt6%2BekkpjgJBIeEsUTFxtpj2eQxCBEzEBBk%2BfvF2mA5pNXUEBWGR0bEttfWNWYNdPUUlAwCUtqhexMjsHAD0KwDUACoAngmY69vzxOtoWOsI0Zik6yTrtKhM6OuG65iqrAn0AHQmGgCC5gAzMFkN4ziZAW5gJgiAkCF8EBDsL8AWZgQxQV5wZCFAR8KgEUiUcECOsWExgusICTnsRgMhrsgEHV1gAqOrAABuJgArFYeQARabrEwAdis/3WUpOzOOpkBEr%2B0pOAlx61xxC8DhucLSOqqCl5/IFIsBJrFit%2BAE4LeYzBdaAk7dcGKgAPocnyMAjXUJyAIBa5gDgIYNigWkFHWi1%2BgPhlHK%2BMKhPSgDuCDo%2BwgAFouOswGAISaIMhTSbobCCG77kYqRyGbSudc7Uhnfq0gpff6AtNeyLxSnlVKFKnCEyqchhbbJUPZ6IlPmQ8GQIPZ2uEsQSVQIC2Kk6eW4GHbphDFWvz%2BsIsRMEwANan1fnrBUJheWgEFczi9Djdbndme0KnudZghoBhCG2XlD2PB8v2/aUrxve9kzgxNRQFVd43%2BLC/g4WZaE4HleD8DgtFIVBODcaxrHVI4lhFNEeFID9SLw2ZbxAQEeS%2BKQrUBDQNB5K0rQANh5AAOQFxP0ThJGIzReAojheAUEANGYhTZjgWAkDQFgEkzMgKBLVB9MMkA6hYLgNH4vg6AIaJVIgCIFNICJgjqbZOCYvS2EEAB5BhaC81jSCwckjHEUL8GvdpOUwVTQreNovAc1ySQqVzaDwK9PI8LBXIITcWG8vC%2BAMYAFAANTwTBU38vYSKY/hBBEMR2CkGRBEUFR1FC3R4gMIwUGoyx9By1TIFmVBdVVThs38sjWnaZwIFcEY/DMaRAmCXpin6LjEmSVIBA22JpByE6GAmPoYkO5aqk6YZPCac7ykqDohm6XbJgOnlbC%2Bs6toB8YftuzieVmBQ6I65jr2WHh8MI%2BTQqUv4ACUAFl1npUtrK%2BQEqWyhgvFUYUICoyxrGuXBCFuIF4nWDwzPoY4GemXgWK0XtSA4/ivlFYSeRsq0uCtDQpDRf6CI4OTSBIsilJUtSNNYrSYEQFBTIM1nyEoPSdf6YA%2BLs99HMoFzQvc5hiBCnzTL8ghAuC1zwsMYAorImK2kceLErI5LkFShHeAymWyOy3Lbfy5YyKKvASu4MqqAq6ravqxrSq64RRHETqWvkJQ1Fc3QzH0d2RqpsbI8miBptmhhEoWpaKh9tIXAYdwXqyQFRVIHbCnBwFASO3I0jO3vR6um79rukeHs%2BrozukheBCe77B9nzj58B7u/BXr6Z6mYeoZhvQiswEOkY4Ij5dcpTVHEkTsxEyQceQUsrQJqlKasMb1lpkQNmjFrjM0NsAwEZgOaq25rMC4jx%2Bh115pxSQXxBJcDFjySQ4kuCQNFICK0MlZYo0VpwZW6kuZsSIWYEhikyEwKofFYgKRnCSCAA%3D%3D)


I think `cmp` on arm
```asm
cmp     r3, #-1
```
yields different flags than the `cmp on x86
```asm
cmp     BYTE PTR [rbp-1], -1
```