### PR TITLE
Fix bw test all_sync variable

### DIFF
--- a/src/rmamt_bw.c
+++ b/src/rmamt_bw.c
@@ -212,7 +212,7 @@ int main(int argc,char *argv[])
             args[i].min_size = min_size;
             args[i].win = rmamt_win_per_thread ? win[i] : win[0];
             args[i].group = group;
-            args[i].all_sync = (RMAMT_ALL_FLUSH == rmamt_sync) || (RMAMT_FENCE == rmamt_sync);
+            args[i].all_sync = rmamt_win_per_thread ? 1 : 0;
             args[i].target = !(rank & 1);
             args[i].comm = leader_comm;
 


### PR DESCRIPTION
When -w is set, every thread should do sync, but when there is only a single window (with multiple threads), only thread 0 needs to do Win sync, and other threads, should just participate in thread_barrier.

This fix is applicable only to the bw test, bibw probably needs a fix as well, but needs to be verified before opening a PR.

Signed-off-by: Mamzi Bayatpour <mbayatpour@nvidia.com>
Co-authored-by: Tomislav Janjusic <tomislavj@nvidia.com>>